### PR TITLE
rmate defaults update to host

### DIFF
--- a/rmate
+++ b/rmate
@@ -15,7 +15,7 @@ class Settings
   attr_accessor :host, :port, :wait, :force, :verbose
 
   def initialize
-    @host, @port = 'localhost', 52698
+    @host, @port = 'auto', 52698
 
     @host = ENV['RMATE_HOST'].to_s if ENV.has_key? 'RMATE_HOST'
     @port = ENV['RMATE_PORT'].to_i if ENV.has_key? 'RMATE_PORT'
@@ -29,6 +29,8 @@ class Settings
 
     if @host == 'auto' and (conn = ENV['SSH_CONNECTION'])
       @host = conn.split(' ').first
+    else
+      @host = 'localhost'
     end
   end
 


### PR DESCRIPTION
I made host='auto' by default to start. If you are in an SSH connection then it sets that automatically as it did before. If you are not in an SSH connection, then it sets host=localhost. This update has worked really nicely for me so far on several remote linux systems, and my mac locally. This happens before users arguments are parsed so that still works if one wants to override the defaults. Enjoy!
