### PR TITLE
Copy backup on save

### DIFF
--- a/rmate
+++ b/rmate
@@ -100,16 +100,20 @@ end
 
 def handle_save(socket, variables, data)
   path = variables["token"]
-  $stderr.puts "Saving #{path}" if $settings.verbose
-  begin
-    backup_path = "#{path}~"
-    backup_path = "#{backup_path}~" while File.exists? backup_path
-    FileUtils.cp(path, backup_path, :preserve => true) if File.exists?(path)
-    open(path, 'wb') { |file| file << data }
-    File.unlink(backup_path) if File.exist? backup_path
-  rescue
-    # TODO We probably want some way to notify the server app that the save failed
-    $stderr.puts "Save failed! #{$!}" if $settings.verbose
+  if File.writable? path
+    $stderr.puts "Saving #{path}" if $settings.verbose
+    begin
+      backup_path = "#{path}~"
+      backup_path = "#{backup_path}~" while File.exists? backup_path
+      FileUtils.cp(path, backup_path, :preserve => true) if File.exists?(path)
+      open(path, 'wb') { |file| file << data }    
+      File.unlink(backup_path) if File.exist? backup_path
+    rescue
+      # TODO We probably want some way to notify the server app that the save failed
+      $stderr.puts "Save failed! #{$!}" if $settings.verbose
+    end
+  else
+    $stderr.puts "Skipping save, file not writable." if $settings.verbose
   end
 end
 


### PR DESCRIPTION
This is a proposed solution to issue #11.

Rather than create a hard link to the original, write to a temp file, then copy the temp file over the original,  we copy the original, then write the new file contents directly to the original file.   This preserves the files owner and group (and permissions).

This allows using `rmate` to edit files where you are not the owner of the file.
