### PR TITLE
Present error message and abort if user tries to rmate a directory.

### DIFF
--- a/bin/rmate
+++ b/bin/rmate
@@ -171,6 +171,7 @@ if __FILE__ == $PROGRAM_NAME
   cmds = []
   ARGV.each_index do |idx|
     path = ARGV[idx]
+    abort "'#{path}' is a directory! Aborting." if File.directory? path
     abort "File #{path} is not writable! Use -f/--force to open anyway." unless $settings.force or File.writable? path or not File.exists? path
     $stderr.puts "File #{path} is not writable. Opening anyway." if not File.writable? path and File.exists? path and $settings.verbose
     cmd                 = Rmate::Command.new("open")


### PR DESCRIPTION
I was confused when I couldn't rmate a directory, had to look on GitHub for an issue, and subsequently found https://github.com/textmate/rmate/issues/9, which was already discussed and closed. This will present an error to the user so they know this is expected behavior. 
