### PR TITLE
Allow reading from stdin (similar to local `mate`)

### DIFF
--- a/bin/rmate
+++ b/bin/rmate
@@ -87,6 +87,11 @@ module Rmate
        @data = File.open(path, "rb") { |io| io.read(@size) }
      end
 
+     def read_stdin
+       @data = $stdin.read
+       @size = @data.size
+     end
+
      def send(socket)
        socket.puts @command
        @variables.each_pair do |name, value|
@@ -169,22 +174,32 @@ if __FILE__ == $PROGRAM_NAME
 
   ## Parse arguments.
   cmds = []
+
+  ARGV << '-' if ARGV.empty? and (!$stdin.tty? or $settings.wait)
+
   ARGV.each_index do |idx|
     path = ARGV[idx]
-    abort "'#{path}' is a directory! Aborting." if File.directory? path
-    abort "File #{path} is not writable! Use -f/--force to open anyway." unless $settings.force or File.writable? path or not File.exists? path
-    $stderr.puts "File #{path} is not writable. Opening anyway." if not File.writable? path and File.exists? path and $settings.verbose
+    if path == '-'
+      $stderr.puts "Reading from stdin, press ^D to stop" if $stdin.tty?
+    else
+      abort "'#{path}' is a directory! Aborting." if File.directory? path
+      abort "File #{path} is not writable! Use -f/--force to open anyway." unless $settings.force or File.writable? path or not File.exists? path
+      $stderr.puts "File #{path} is not writable. Opening anyway." if not File.writable? path and File.exists? path and $settings.verbose
+    end
     cmd                 = Rmate::Command.new("open")
-    cmd['display-name'] = "#{Socket.gethostname}:#{path}"
+    cmd['display-name'] = "#{Socket.gethostname}:untitled (stdin)" if path == '-'
+    cmd['display-name'] = "#{Socket.gethostname}:#{path}" unless path == '-'
     cmd['display-name'] = $settings.names[idx] if $settings.names.length > idx
-    cmd['real-path']    = File.expand_path(path)
+    cmd['real-path']    = File.expand_path(path) unless path == '-'
     cmd['data-on-save'] = true
     cmd['re-activate']  = true
     cmd['token']        = path
     cmd['selection']    = $settings.lines[idx] if $settings.lines.length > idx
+    cmd['file-type']    = 'txt'                if path == '-'
     cmd['file-type']    = $settings.types[idx] if $settings.types.length > idx
-    cmd.read_file(path)               if File.exist? path
-    cmd['data']         = "0"     unless File.exist? path
+    cmd.read_stdin                    if path == '-'
+    cmd.read_file(path)               if path != '-' and File.exist? path
+    cmd['data']         = "0"     unless path == '-' or  File.exist? path
     cmds << cmd
   end
 


### PR DESCRIPTION
This change provides same functionality like local `mate` tool for reading from stdin, either when stdin is not a TTY or `-` input file is specified.
