### PR TITLE
Updated exists? to exist? to prevent deprecated call messages.

### DIFF
--- a/bin/rmate
+++ b/bin/rmate
@@ -110,12 +110,12 @@ module Rmate
 
   def handle_save(socket, variables, data)
     path = variables["token"]
-    if File.writable?(path) || !File.exists?(path)
+    if File.writable?(path) || !File.exist?(path)
       $stderr.puts "Saving #{path}" if $settings.verbose
       begin
         backup_path = "#{path}~"
-        backup_path = "#{backup_path}~" while File.exists? backup_path
-        FileUtils.cp(path, backup_path, :preserve => true) if File.exists?(path)
+        backup_path = "#{backup_path}~" while File.exist? backup_path
+        FileUtils.cp(path, backup_path, :preserve => true) if File.exist?(path)
         open(path, 'wb') { |file| file << data }
         File.unlink(backup_path) if File.exist? backup_path
       rescue
@@ -183,8 +183,8 @@ if __FILE__ == $PROGRAM_NAME
       $stderr.puts "Reading from stdin, press ^D to stop" if $stdin.tty?
     else
       abort "'#{path}' is a directory! Aborting." if File.directory? path
-      abort "File #{path} is not writable! Use -f/--force to open anyway." unless $settings.force or File.writable? path or not File.exists? path
-      $stderr.puts "File #{path} is not writable. Opening anyway." if not File.writable? path and File.exists? path and $settings.verbose
+      abort "File #{path} is not writable! Use -f/--force to open anyway." unless $settings.force or File.writable? path or not File.exist? path
+      $stderr.puts "File #{path} is not writable. Opening anyway." if not File.writable? path and File.exist? path and $settings.verbose
     end
     cmd                 = Rmate::Command.new("open")
     cmd['display-name'] = "#{Socket.gethostname}:untitled (stdin)" if path == '-'


### PR DESCRIPTION
When saving a file using Ruby 2.1.0 you would get the following console error/warning:

/root/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rmate-1.5.5/bin/rmate:108: warning: File.exists? is a deprecated name, use File.exist? instead
/root/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rmate-1.5.5/bin/rmate:109: warning: File.exists? is a deprecated name, use File.exist? instead
