### PR TITLE
convert Process.fork call to Process.spawn

### DIFF
--- a/bin/rmate
+++ b/bin/rmate
@@ -5,6 +5,7 @@ $VERBOSE = true                         # -w
 $KCODE   = "U" if RUBY_VERSION < "1.9"  # -KU
 
 require 'optparse'
+require 'rbconfig'
 require 'socket'
 require 'tempfile'
 require 'yaml'
@@ -203,9 +204,8 @@ ARGV.each_index do |idx|
 end
 
 unless $settings.wait
-  pid = fork do
-    Rmate::connect_and_handle_cmds($settings.host, $settings.port, cmds)
-  end
+  command = [ RbConfig.ruby, __FILE__, "-w" ] + ARGV
+  pid = Process.spawn(*command)
   Process.detach(pid)
 else
   Rmate::connect_and_handle_cmds($settings.host, $settings.port, cmds)


### PR DESCRIPTION
`Process.fork` makes `rmate` tricky on Windows environments, and not using windows is a great use case for `rmate`.

The downside is that `fork` is replaced by `spawn` (and a bit of `RbConfig`), so the changes in the pull request require ruby 1.9.x.  If the version requirement is a dealbreaker, I can clean the gem parts out of this repo, and maintain is as a port like the bash script port (which doesn't solve this case -- if an environment supported `/dev/tcp`, it probably supports `Process.fork`).
