### PR TITLE
Added an option to connect through a UNIX socket

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -4,6 +4,10 @@ If you wish to activate TextMate from an ssh session you can do so by copying th
 
 	ssh -R 52698:localhost:52698 user@example.org
 
+or, if using unix sockets (available with OpenSSH v6.7 and above):
+
+    ssh -R /path/to/rmate.sock:localhost:52698 user@example.org
+
 # Install
 
 ## Rubygems
@@ -33,10 +37,11 @@ If `~/bin` is not already in your `PATH` then you may want to add something like
 
 Call `rmate --help` for a list of options. Default options can be set in `/etc/rmate.rc` or `~/.rmate.rc`, e.g.:
 
-	host: auto  # prefer host from SSH_CONNECTION over localhost
+	host: auto        # prefer host from SSH_CONNECTION over localhost
 	port: 52698
+	unixsocket: nil   # Do not use a UNIX socket by default
 
-You can also set the `RMATE_HOST` and `RMATE_PORT` environment variables.
+You can also set the `RMATE_HOST`, `RMATE_PORT` and `RMATE_UNIXSOCKET` environment variables.
 
 For more info see this [blog post about rmate](http://blog.macromates.com/2011/mate-and-rmate/ "TextMate Blog » mate and rmate").
 

--- a/README.mdown
+++ b/README.mdown
@@ -37,9 +37,9 @@ If `~/bin` is not already in your `PATH` then you may want to add something like
 
 Call `rmate --help` for a list of options. Default options can be set in `/etc/rmate.rc` or `~/.rmate.rc`, e.g.:
 
-	host: auto        # prefer host from SSH_CONNECTION over localhost
+	host: auto                      # prefer host from SSH_CONNECTION over localhost
 	port: 52698
-	unixsocket: nil   # Do not use a UNIX socket by default
+	unixsocket: ~/.rmate.socket   # Use this socket file if it exists
 
 You can also set the `RMATE_HOST`, `RMATE_PORT` and `RMATE_UNIXSOCKET` environment variables.
 

--- a/bin/rmate
+++ b/bin/rmate
@@ -16,7 +16,7 @@ module Rmate
   VERSION_STRING = "rmate version #{Rmate::VERSION} (#{Rmate::DATE})"
 
   class Settings
-    attr_accessor :host, :port, :wait, :force, :verbose, :lines, :names, :types
+    attr_accessor :host, :port, :unixsocket, :wait, :force, :verbose, :lines, :names, :types
 
     def initialize
       @host, @port = 'localhost', 52698
@@ -24,14 +24,16 @@ module Rmate
       @wait    = false
       @force   = false
       @verbose = false
+      @unixsocket  = nil
       @lines   = []
       @names   = []
       @types   = []
 
       read_disk_settings
 
-      @host = ENV['RMATE_HOST'].to_s if ENV.has_key? 'RMATE_HOST'
-      @port = ENV['RMATE_PORT'].to_i if ENV.has_key? 'RMATE_PORT'
+      @host       = ENV['RMATE_HOST'].to_s       if ENV.has_key? 'RMATE_HOST'
+      @port       = ENV['RMATE_PORT'].to_i       if ENV.has_key? 'RMATE_PORT'
+      @unixsocket = ENV['RMATE_UNIXSOCKET'].to_i if ENV.has_key? 'RMATE_UNIXSOCKET'
 
       parse_cli_options
 
@@ -43,22 +45,24 @@ module Rmate
         file = File.expand_path current_file
         if File.exist? file
           params = YAML::load(File.open(file))
-          @host = params["host"] unless params["host"].nil?
-          @port = params["port"] unless params["port"].nil?
+          @host       = params["host"] unless params["host"].nil?
+          @port       = params["port"] unless params["port"].nil?
+          @unixsocket = params["unixsocket"] unless params["unixsocket"].nil?
         end
       end
     end
 
     def parse_cli_options
       OptionParser.new do |o|
-        o.on(           '--host=name',       "Connect to host.", "Use 'auto' to detect the host from SSH.", "Defaults to #{@host}.") { |v| @host    = v          }
-        o.on('-p',      '--port=#', Integer, "Port number to use for connection.", "Defaults to #{@port}.")                          { |v| @port    = v          }
-        o.on('-w',      '--[no-]wait',       'Wait for file to be closed by TextMate.')                                              { |v| @wait    = v          }
-        o.on('-l',      '--line [NUMBER]',   'Place caret on line [NUMBER] after loading file.')                                     { |v| @lines <<= v          }
-        o.on('-m',      '--name [NAME]',     'The display name shown in TextMate.')                                                  { |v| @names <<= v          }
-        o.on('-t',      '--type [TYPE]',     'Treat file as having [TYPE].')                                                         { |v| @types <<= v          }
-        o.on('-f',      '--force',           'Open even if the file is not writable.')                                               { |v| @force   = v          }
-        o.on('-v',      '--verbose',         'Verbose logging messages.')                                                            { |v| @verbose = v          }
+        o.on(           '--host=name',       "Connect to host.", "Use 'auto' to detect the host from SSH.", "Defaults to #{@host}.") { |v| @host       = v       }
+        o.on('-s',      '--unixsocket=name', "Connect to UNIX socket.", "Takes precedence over host/port")                           { |v| @unixsocket = v       }
+        o.on('-p',      '--port=#', Integer, "Port number to use for connection.", "Defaults to #{@port}.")                          { |v| @port       = v       }
+        o.on('-w',      '--[no-]wait',       'Wait for file to be closed by TextMate.')                                              { |v| @wait       = v       }
+        o.on('-l',      '--line [NUMBER]',   'Place caret on line [NUMBER] after loading file.')                                     { |v| @lines      <<= v     }
+        o.on('-m',      '--name [NAME]',     'The display name shown in TextMate.')                                                  { |v| @names      <<= v     }
+        o.on('-t',      '--type [TYPE]',     'Treat file as having [TYPE].')                                                         { |v| @types      <<= v     }
+        o.on('-f',      '--force',           'Open even if the file is not writable.')                                               { |v| @force      = v       }
+        o.on('-v',      '--verbose',         'Verbose logging messages.')                                                            { |v| @verbose    = v       }
         o.on_tail('-h', '--help',            'Show this message.')                                                                   { puts o; exit              }
         o.on_tail(      '--version',         'Show version.')                                                                        { puts VERSION_STRING; exit }
         o.parse!
@@ -153,8 +157,15 @@ module Rmate
     end
   end
 
-  def connect_and_handle_cmds(host, port, cmds)
-    socket = TCPSocket.new(host, port)
+  def connect_and_handle_cmds(host, port, unixsocketpath, cmds)
+    socket = nil
+    if unixsocketpath.nil?
+      # socket is now ready to communicate.
+      socket = TCPSocket.new(host, port)
+    else
+      $stderr.puts "Using UNIX socket to connect: ‘#{unixsocketpath}’" if $settings.verbose
+      socket = UNIXSocket.new(unixsocketpath)
+    end
     server_info = socket.readline.chomp
     $stderr.puts "Connect: ‘#{server_info}’" if $settings.verbose
 
@@ -204,9 +215,9 @@ end
 
 unless $settings.wait
   pid = fork do
-    Rmate::connect_and_handle_cmds($settings.host, $settings.port, cmds)
+    Rmate::connect_and_handle_cmds($settings.host, $settings.port, $settings.unixsocket, cmds)
   end
   Process.detach(pid)
 else
-  Rmate::connect_and_handle_cmds($settings.host, $settings.port, cmds)
+  Rmate::connect_and_handle_cmds($settings.host, $settings.port, $settings.unixsocket, cmds)
 end

--- a/bin/rmate
+++ b/bin/rmate
@@ -19,12 +19,11 @@ module Rmate
     attr_accessor :host, :port, :unixsocket, :wait, :force, :verbose, :lines, :names, :types
 
     def initialize
-      @host, @port = 'localhost', 52698
+      @host, @port, @unixsocket = 'localhost', 52698, '~/.rmate.socket'
 
       @wait    = false
       @force   = false
       @verbose = false
-      @unixsocket  = nil
       @lines   = []
       @names   = []
       @types   = []
@@ -55,7 +54,8 @@ module Rmate
     def parse_cli_options
       OptionParser.new do |o|
         o.on(           '--host=name',       "Connect to host.", "Use 'auto' to detect the host from SSH.", "Defaults to #{@host}.") { |v| @host       = v       }
-        o.on('-s',      '--unixsocket=name', "Connect to UNIX socket.", "Takes precedence over host/port")                           { |v| @unixsocket = v       }
+        o.on('-s',      '--unixsocket=name', "UNIX socket path.", "Takes precedence over host/port if the file exists", \
+                                                                  "Default #{@unixsocket}")                                          { |v| @unixsocket = v       }
         o.on('-p',      '--port=#', Integer, "Port number to use for connection.", "Defaults to #{@port}.")                          { |v| @port       = v       }
         o.on('-w',      '--[no-]wait',       'Wait for file to be closed by TextMate.')                                              { |v| @wait       = v       }
         o.on('-l',      '--line [NUMBER]',   'Place caret on line [NUMBER] after loading file.')                                     { |v| @lines      <<= v     }
@@ -159,7 +159,9 @@ module Rmate
 
   def connect_and_handle_cmds(host, port, unixsocketpath, cmds)
     socket = nil
-    if unixsocketpath.nil?
+    unixsocketpath = File.expand_path(unixsocketpath) unless unixsocketpath.nil?
+    $stderr.puts "Looking at #{unixsocketpath}"
+    if unixsocketpath.nil? || !File.exist?(unixsocketpath)
       # socket is now ready to communicate.
       socket = TCPSocket.new(host, port)
     else


### PR DESCRIPTION
This patch adds an option (--unixsocket or -s) to use a UNIX socket rather than a TCP socket. This is useful when the remote host is a shared server. 