### PR TITLE
Allow /usr/local/etc/rmate.rc for configuration

### DIFF
--- a/bin/rmate
+++ b/bin/rmate
@@ -40,7 +40,7 @@ module Rmate
     end
 
     def read_disk_settings
-      [ "/etc/rmate.rc", "~/.rmate.rc"].each do |current_file|
+      [ "/etc/rmate.rc", "/usr/local/etc/rmate.rc", "~/.rmate.rc"].each do |current_file|
         file = File.expand_path current_file
         if File.exist? file
           params = YAML::load(File.open(file))


### PR DESCRIPTION
It's customary on systems such as FreeBSD, etc. for `/usr/local/etc` to be the preferred place for config files for user-installed programs. This commit adds that path to those searched when loading `rmate.rc`.