### PR TITLE
Use LC_* environment variables

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -42,6 +42,9 @@ Call `rmate --help` for a list of options. Default options can be set in `/etc/r
 	unixsocket: ~/.rmate.socket  # Use this socket file if it exists
 
 You can also set the `RMATE_HOST`, `RMATE_PORT` and `RMATE_UNIXSOCKET` environment variables.
+The same environment variables can be prefixed by `LC_` (e.g. `LC_RMATE_HOST`) so that they can
+through stricter SSH server configurations (`LC_*` variables take precedence over other environment
+variables).
 
 For more info see this [blog post about rmate](http://blog.macromates.com/2011/mate-and-rmate/ "TextMate Blog » mate and rmate").
 

--- a/bin/rmate
+++ b/bin/rmate
@@ -34,6 +34,11 @@ module Rmate
       @port       = ENV['RMATE_PORT'].to_i       if ENV.has_key? 'RMATE_PORT'
       @unixsocket = ENV['RMATE_UNIXSOCKET'].to_s if ENV.has_key? 'RMATE_UNIXSOCKET'
 
+      # Use LC_* variables that can be set more easily with ssh
+      @host       = ENV['LC_RMATE_HOST'].to_s       if ENV.has_key? 'LC_RMATE_HOST'
+      @port       = ENV['LC_RMATE_PORT'].to_i       if ENV.has_key? 'LC_RMATE_PORT'
+      @unixsocket = ENV['LC_RMATE_UNIXSOCKET'].to_s if ENV.has_key? 'LC_RMATE_UNIXSOCKET'
+
       parse_cli_options
 
       @host = parse_ssh_connection if @host == 'auto'


### PR DESCRIPTION
This allows to go through stricter SSH server policies that only allow LC_* variables through